### PR TITLE
Run LAMMPS experiment with Faasm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,4 @@
 [submodule "third-party/lammps"]
 	path = third-party/lammps
 	url = https://github.com/faasm/lammps
+    branch = faasm

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -25,6 +25,7 @@ ns.add_collection(genomics)
 ns.add_collection(polybench)
 ns.add_collection(prk)
 ns.add_collection(tensorflow)
+ns.add_collection(lammps)
 
 # Group benchmarking tasks
 bench_ns = Collection("bench")

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -12,6 +12,7 @@ from . import (
     dev,
     experiments,
     genomics,
+    lammps,
     polybench,
     prk,
     tensorflow,
@@ -22,10 +23,10 @@ ns.add_collection(data)
 ns.add_collection(dev)
 ns.add_collection(experiments)
 ns.add_collection(genomics)
+ns.add_collection(lammps)
 ns.add_collection(polybench)
 ns.add_collection(prk)
 ns.add_collection(tensorflow)
-ns.add_collection(lammps)
 
 # Group benchmarking tasks
 bench_ns = Collection("bench")

--- a/tasks/lammps.py
+++ b/tasks/lammps.py
@@ -9,44 +9,49 @@ from invoke import task
 
 from tasks.util.env import EXPERIMENTS_THIRD_PARTY
 
-LAMMPS_DIR = join(EXPERIMENTS_THIRD_PARTY, "horovod")
+LAMMPS_DIR = join(EXPERIMENTS_THIRD_PARTY, "lammps")
 
 
 # The LAMMPS CMake build instructions can be found in the following link
 # https://lammps.sandia.gov/doc/Build_cmake.html
 
 
-@task
-def lib(ctx, clean=False):
-    work_dir = join(LAMMPS_DIR, "build")
+@task(default=True)
+def build(ctx, clean=False):
+    """
+    Builds the LAMMPS Molecular Dynamics Simulator
+    https://lammps.sandia.gov
+    """
+    work_dir = join(LAMMPS_DIR, "build")
+    cmake_dir = join(LAMMPS_DIR, "cmake")
 
-    clean_dir(work_dir, clean)
+    clean_dir(work_dir, clean)
 
-    env_vars = copy(os.environ)
+    env_vars = copy(os.environ)
 
-    cmake_cmd = [
-        "cmake",
-        "-GNinja",
-        "-DPKG_BODY=on",
-        "-DFAASM_BUILD_TYPE=wasm",
-        "-DCMAKE_TOOLCHAIN_FILE={}".format(FAASM_TOOLCHAIN_FILE),
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX={}".format(SYSROOT_INSTALL_PREFIX),
-        "-DHAVE_CUDA=OFF",
-        LAMMPS_DIR,
-    ]
+    cmake_cmd = [
+        "cmake",
+        "-GNinja",
+        "PKG_BODY=on", # We compile an additional package for experiments
+        "-DFAASM_BUILD_TYPE=wasm",
+        "-DCMAKE_TOOLCHAIN_FILE={}".format(FAASM_TOOLCHAIN_FILE),
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_INSTALL_PREFIX={}".format(SYSROOT_INSTALL_PREFIX),
+        cmake_dir,
+    ]
 
-    cmake_str = " ".join(cmake_cmd)
-    print(cmake_str)
+    cmake_str = " ".join(cmake_cmd)
+    print(cmake_str)
 
-    res = run(cmake_str, shell=True, cwd=work_dir, env=env_vars)
-    if res.returncode != 0:
-        raise RuntimeError("Horovod CMake config failed")
+    res = run(cmake_str, shell=True, cwd=work_dir, env=env_vars)
+    if res.returncode != 0:
+        raise RuntimeError("LAMMPS CMake config failed")
 
-    res = run("ninja", shell=True, cwd=work_dir)
-    if res.returncode != 0:
-        raise RuntimeError("Horovod build failed")
+    res = run("ninja", shell=True, cwd=work_dir)
+    if res.returncode != 0:
+        raise RuntimeError("LAMMPS build failed")
 
-    res = run("ninja install", shell=True, cwd=work_dir)
-    if res.returncode != 0:
-        raise RuntimeError("Horovod install failed")
+    # @csegarra: Is it advisable to actually install the binaries?
+#    res = run("ninja install", shell=True, cwd=work_dir)
+#    if res.returncode != 0:
+#        raise RuntimeError("LAMMPS install failed")

--- a/tasks/lammps.py
+++ b/tasks/lammps.py
@@ -3,6 +3,7 @@ from subprocess import run
 from copy import copy
 import os
 
+from faasmcli.util.endpoints import get_upload_host_port
 from faasmcli.util.env import FAASM_TOOLCHAIN_FILE, SYSROOT_INSTALL_PREFIX
 from faasmcli.util.files import clean_dir
 from invoke import task
@@ -16,11 +17,10 @@ LAMMPS_DIR = join(EXPERIMENTS_THIRD_PARTY, "lammps")
 # https://lammps.sandia.gov/doc/Build_cmake.html
 
 
-@task(default=True)
+@task
 def build(ctx, clean=False):
     """
-    Builds the LAMMPS Molecular Dynamics Simulator
-    https://lammps.sandia.gov
+    Build and install the LAMMPS Molecular Dynamics Simulator
     """
     work_dir = join(LAMMPS_DIR, "build")
     cmake_dir = join(LAMMPS_DIR, "cmake")
@@ -32,7 +32,7 @@ def build(ctx, clean=False):
     cmake_cmd = [
         "cmake",
         "-GNinja",
-        "PKG_BODY=on", # We compile an additional package for experiments
+        "PKG_BODY=on",  # We compile an additional package for experiments
         "-DFAASM_BUILD_TYPE=wasm",
         "-DCMAKE_TOOLCHAIN_FILE={}".format(FAASM_TOOLCHAIN_FILE),
         "-DCMAKE_BUILD_TYPE=Release",
@@ -51,7 +51,14 @@ def build(ctx, clean=False):
     if res.returncode != 0:
         raise RuntimeError("LAMMPS build failed")
 
-    # @csegarra: Is it advisable to actually install the binaries?
-#    res = run("ninja install", shell=True, cwd=work_dir)
-#    if res.returncode != 0:
-#        raise RuntimeError("LAMMPS install failed")
+    res = run("ninja install", shell=True, cwd=work_dir)
+    if res.returncode != 0:
+        raise RuntimeError("LAMMPS install failed")
+
+
+@task
+def run_lammps(ctx):
+    """
+    Run a LAMMPS task
+    """
+    pass

--- a/tasks/lammps.py
+++ b/tasks/lammps.py
@@ -1,0 +1,52 @@
+from os.path import join
+from subprocess import run
+from copy import copy
+import os
+
+from faasmcli.util.env import FAASM_TOOLCHAIN_FILE, SYSROOT_INSTALL_PREFIX
+from faasmcli.util.files import clean_dir
+from invoke import task
+
+from tasks.util.env import EXPERIMENTS_THIRD_PARTY
+
+LAMMPS_DIR = join(EXPERIMENTS_THIRD_PARTY, "horovod")
+
+
+# The LAMMPS CMake build instructions can be found in the following link
+# https://lammps.sandia.gov/doc/Build_cmake.html
+
+
+@task
+def lib(ctx, clean=False):
+    work_dir = join(LAMMPS_DIR, "build")
+
+    clean_dir(work_dir, clean)
+
+    env_vars = copy(os.environ)
+
+    cmake_cmd = [
+        "cmake",
+        "-GNinja",
+        "-DPKG_BODY=on",
+        "-DFAASM_BUILD_TYPE=wasm",
+        "-DCMAKE_TOOLCHAIN_FILE={}".format(FAASM_TOOLCHAIN_FILE),
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_INSTALL_PREFIX={}".format(SYSROOT_INSTALL_PREFIX),
+        "-DHAVE_CUDA=OFF",
+        LAMMPS_DIR,
+    ]
+
+    cmake_str = " ".join(cmake_cmd)
+    print(cmake_str)
+
+    res = run(cmake_str, shell=True, cwd=work_dir, env=env_vars)
+    if res.returncode != 0:
+        raise RuntimeError("Horovod CMake config failed")
+
+    res = run("ninja", shell=True, cwd=work_dir)
+    if res.returncode != 0:
+        raise RuntimeError("Horovod build failed")
+
+    res = run("ninja install", shell=True, cwd=work_dir)
+    if res.returncode != 0:
+        raise RuntimeError("Horovod install failed")

--- a/tasks/lammps.py
+++ b/tasks/lammps.py
@@ -4,8 +4,8 @@ from copy import copy
 import os
 
 from faasmcli.util.endpoints import get_upload_host_port
-from faasmcli.util.env import FAASM_TOOLCHAIN_FILE, SYSROOT_INSTALL_PREFIX
-from faasmcli.util.env import FAASM_HOME
+from faasmtools.build import CMAKE_TOOLCHAIN_FILE
+from faasmcli.util.env import PROJ_ROOT
 from faasmcli.util.files import clean_dir
 from invoke import task
 
@@ -26,7 +26,7 @@ def build(ctx, clean=False):
     work_dir = join(LAMMPS_DIR, "build")
     cmake_dir = join(LAMMPS_DIR, "cmake")
     install_dir = join(LAMMPS_DIR, "install")
-    wasm_path = join(FAASM_HOME, "lammps", "test", "function.wasm")
+    wasm_path = join(PROJ_ROOT, "wasm", "lammps", "test", "function.wasm")
 
     clean_dir(work_dir, clean)
     clean_dir(install_dir, clean)
@@ -38,7 +38,7 @@ def build(ctx, clean=False):
         "-GNinja",
         "PKG_BODY=on",  # We compile an additional package for experiments
         "-DFAASM_BUILD_TYPE=wasm",
-        "-DCMAKE_TOOLCHAIN_FILE={}".format(FAASM_TOOLCHAIN_FILE),
+        "-DCMAKE_TOOLCHAIN_FILE={}".format(CMAKE_TOOLCHAIN_FILE),
         "-DCMAKE_BUILD_TYPE=Release",
         "-DCMAKE_INSTALL_PREFIX={}".format(install_dir),
         cmake_dir,
@@ -61,9 +61,6 @@ def build(ctx, clean=False):
 
     # Copy binary to wasm/lammps/test/function.wasm
     print("cp {}/bin/lmp {}".format(install_dir, wasm_path))
-    print(
-        "cp /home/csegarra/Work/IMP/sless-wasm/faasm-experiments/third-party/lammps/install/bin/lmp /home/csegarra/Work/IMP/sless-wasm/faasm/wasm/lammps/test/function.wasm"
-    )
 
 
 @task

--- a/tasks/lammps.py
+++ b/tasks/lammps.py
@@ -24,8 +24,10 @@ def build(ctx, clean=False):
     """
     work_dir = join(LAMMPS_DIR, "build")
     cmake_dir = join(LAMMPS_DIR, "cmake")
+    install_dir = join(LAMMPS_DIR, "install")
 
     clean_dir(work_dir, clean)
+    clean_dir(install_dir, clean)
 
     env_vars = copy(os.environ)
 
@@ -36,7 +38,7 @@ def build(ctx, clean=False):
         "-DFAASM_BUILD_TYPE=wasm",
         "-DCMAKE_TOOLCHAIN_FILE={}".format(FAASM_TOOLCHAIN_FILE),
         "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX={}".format(SYSROOT_INSTALL_PREFIX),
+        "-DCMAKE_INSTALL_PREFIX={}".format(install_dir),
         cmake_dir,
     ]
 

--- a/tasks/lammps.py
+++ b/tasks/lammps.py
@@ -5,6 +5,7 @@ import os
 
 from faasmcli.util.endpoints import get_upload_host_port
 from faasmcli.util.env import FAASM_TOOLCHAIN_FILE, SYSROOT_INSTALL_PREFIX
+from faasmcli.util.env import FAASM_HOME
 from faasmcli.util.files import clean_dir
 from invoke import task
 
@@ -25,6 +26,7 @@ def build(ctx, clean=False):
     work_dir = join(LAMMPS_DIR, "build")
     cmake_dir = join(LAMMPS_DIR, "cmake")
     install_dir = join(LAMMPS_DIR, "install")
+    wasm_path = join(FAASM_HOME, "lammps", "test", "function.wasm")
 
     clean_dir(work_dir, clean)
     clean_dir(install_dir, clean)
@@ -56,6 +58,12 @@ def build(ctx, clean=False):
     res = run("ninja install", shell=True, cwd=work_dir)
     if res.returncode != 0:
         raise RuntimeError("LAMMPS install failed")
+
+    # Copy binary to wasm/lammps/test/function.wasm
+    print("cp {}/bin/lmp {}".format(install_dir, wasm_path))
+    print(
+        "cp /home/csegarra/Work/IMP/sless-wasm/faasm-experiments/third-party/lammps/install/bin/lmp /home/csegarra/Work/IMP/sless-wasm/faasm/wasm/lammps/test/function.wasm"
+    )
 
 
 @task


### PR DESCRIPTION
In this PR I take all the necessary steps to run an execution of a `lammps` job with `Faasm` from the experiment side of things. The support required in `faasm` is covered in faasm/faasm#317. In particular in this PR I include the necessary changes to:
* [x] Have LAMMPS as a third-party dependency.
* [x] Build LAMMPS from a task.
* [x] Run LAMMPS from a task.

Closes #13 

Related to faasm/faasm#317