### PR TITLE
Updated the tests to only run on non-draft PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request: 
     branches: [master]
+    types: [review_requested, ready_for_review]
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,10 @@ on:
     branches: [master]
   pull_request: 
     branches: [master]
-    types: [review_requested, ready_for_review]
 
 jobs:
   tests:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     container:
         image: faasm/base-test:0.4.9


### PR DESCRIPTION
The same you did [here](https://github.com/faasm/faasm/commit/95ec36e76974804cfb68ef64ae97bee44137bd30).

P.S: I wanted to be "fully compliant" so I have branched from the current `upstream/master` which does not include the commits we are discussing in #15 (I accidentally did not do it before).